### PR TITLE
Feature/mapping source generator

### DIFF
--- a/src/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry.UnitTests/Aydsko.iRacingTelemetry.UnitTests.csproj
+++ b/src/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry.UnitTests/Aydsko.iRacingTelemetry.UnitTests.csproj
@@ -29,6 +29,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="../Aysdko.iRacingTelemetry.Generators/Aysdko.iRacingTelemetry.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="true" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="mercedesw12_silverstone 2019 gp 2023-08-02 21-44-30.ibt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry.UnitTests/MapperTests.cs
+++ b/src/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry.UnitTests/MapperTests.cs
@@ -1,0 +1,34 @@
+﻿using Aysdko.iRacingTelemetry.Generators.Mapper;
+
+namespace Aydsko.iRacingTelemetry.UnitTests;
+public sealed class MapperTests
+{
+    private DiskClient _diskClient = default!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        var testFilePath = Path.Combine(Environment.CurrentDirectory, "mercedesw12_silverstone 2019 gp 2023-08-02 21-44-30.ibt");
+        _diskClient = await DiskClient.OpenFileAsync(testFilePath).ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task MapperShouldFillTestClass()
+    {
+        var mapper = new MapperTestClass_AysdkoMapper(_diskClient.GetHeaderVariables());
+        var buffer = await _diskClient.ReadBufferLinesAsync().FirstAsync().ConfigureAwait(false);
+        var data = mapper.MapFromBuffer(buffer.Span);
+        Assert.Multiple(() =>
+        {
+            Assert.That(data.SessionTime, Is.EqualTo(TimeSpan.FromSeconds(676.3333330787348)));
+            Assert.That(data.SessionState, Is.EqualTo(SessionState.StateRacing));
+        });
+    }
+}
+
+[AysdkoData(autoMapAllProperties: true)]
+public class MapperTestClass
+{
+    public TimeSpan SessionTime { get; set; }
+    public SessionState SessionState { get; set; }
+}

--- a/src/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry.UnitTests/VariableBufferAccessTests.cs
+++ b/src/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry.UnitTests/VariableBufferAccessTests.cs
@@ -1,6 +1,15 @@
 ﻿namespace Aydsko.iRacingTelemetry.UnitTests;
 public sealed class VariableBufferAccessTests
 {
+    private DiskClient _diskClient = default!;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        var testFilePath = Path.Combine(Environment.CurrentDirectory, "mercedesw12_silverstone 2019 gp 2023-08-02 21-44-30.ibt");
+        _diskClient = await DiskClient.OpenFileAsync(testFilePath).ConfigureAwait(false);
+    }
+
     [Test]
     [TestCase(1.0, (int) 1)]
     [TestCase(1, (float)1.0)]
@@ -8,7 +17,7 @@ public sealed class VariableBufferAccessTests
     [TestCase(1, (TrackLocation)1)]
     public void SafeConvertTypeShouldReturnExpectedValue<T>(object value, T expected)
     {
-        T typedValue = VariableBufferAccess.SafeConvertType<T>(value);
+        var typedValue = VariableBufferAccess.SafeConvertType<T>(value);
         Assert.That(typedValue, Is.EqualTo(expected));
     }
 
@@ -17,7 +26,7 @@ public sealed class VariableBufferAccessTests
     [TestCase("42", "00:00:42")]
     public void SafeConvertTypeShouldConvertToTimeSpan(object value, TimeSpan expected)
     {
-        TimeSpan typedValue = VariableBufferAccess.SafeConvertType<TimeSpan>(value);
+        var typedValue = VariableBufferAccess.SafeConvertType<TimeSpan>(value);
         Assert.That(typedValue, Is.EqualTo(expected));
     }
 
@@ -28,7 +37,18 @@ public sealed class VariableBufferAccessTests
     [TestCase(1, (TrackLocation)1)]
     public void SafeConvertTypeShouldReturnNullabeValue<T>(object value, T expected) where T : struct
     {
-        T? typedValue = VariableBufferAccess.SafeConvertType<T?>(value);
+        var typedValue = VariableBufferAccess.SafeConvertType<T?>(value);
         Assert.That(typedValue, Is.EqualTo(expected));
+    }
+
+    [Test]
+    [TestCase("SessionTime", 676.3333330787348)]
+    [TestCase("SessionState", SessionState.StateRacing)]
+    public async Task GetTypedValueShouldReturnValueFromBuffer<T>(string varHeaderName, T expected)
+    {
+        var header = _diskClient.GetHeaderVariables().First(x => new string(x.Name) == varHeaderName);
+        var buffer = await _diskClient.ReadBufferLinesAsync().FirstAsync().ConfigureAwait(false);
+        var value = VariableBufferAccess.GetTypedValue<T>(buffer.Span, header);
+        Assert.That(value, Is.EqualTo(expected));
     }
 }

--- a/src/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry.UnitTests/VariableBufferAccessTests.cs
+++ b/src/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry.UnitTests/VariableBufferAccessTests.cs
@@ -1,0 +1,34 @@
+﻿namespace Aydsko.iRacingTelemetry.UnitTests;
+public sealed class VariableBufferAccessTests
+{
+    [Test]
+    [TestCase(1.0, (int) 1)]
+    [TestCase(1, (float)1.0)]
+    [TestCase("1", (float)1.0)]
+    [TestCase(1, (TrackLocation)1)]
+    public void SafeConvertTypeShouldReturnExpectedValue<T>(object value, T expected)
+    {
+        T typedValue = VariableBufferAccess.SafeConvertType<T>(value);
+        Assert.That(typedValue, Is.EqualTo(expected));
+    }
+
+    [Test]
+    [TestCase(42, "00:00:42")]
+    [TestCase("42", "00:00:42")]
+    public void SafeConvertTypeShouldConvertToTimeSpan(object value, TimeSpan expected)
+    {
+        TimeSpan typedValue = VariableBufferAccess.SafeConvertType<TimeSpan>(value);
+        Assert.That(typedValue, Is.EqualTo(expected));
+    }
+
+    [Test]
+    [TestCase(1.0, (int)1)]
+    [TestCase(1, (float)1.0)]
+    [TestCase("1", (float)1.0)]
+    [TestCase(1, (TrackLocation)1)]
+    public void SafeConvertTypeShouldReturnNullabeValue<T>(object value, T expected) where T : struct
+    {
+        T? typedValue = VariableBufferAccess.SafeConvertType<T?>(value);
+        Assert.That(typedValue, Is.EqualTo(expected));
+    }
+}

--- a/src/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry.sln
+++ b/src/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry.sln
@@ -11,7 +11,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\Directory.Build.props = ..\Directory.Build.props
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aydsko.iRacingTelemetry.UnitTests", "Aydsko.iRacingTelemetry.UnitTests\Aydsko.iRacingTelemetry.UnitTests.csproj", "{DB276308-5C05-4EEC-9914-B11AD3F37DEA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aydsko.iRacingTelemetry.UnitTests", "Aydsko.iRacingTelemetry.UnitTests\Aydsko.iRacingTelemetry.UnitTests.csproj", "{DB276308-5C05-4EEC-9914-B11AD3F37DEA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aysdko.iRacingTelemetry.Generators", "Aysdko.iRacingTelemetry.Generators\Aysdko.iRacingTelemetry.Generators.csproj", "{1BDF487C-4E58-424A-8BBE-0C2A74BE0AA6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +29,10 @@ Global
 		{DB276308-5C05-4EEC-9914-B11AD3F37DEA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DB276308-5C05-4EEC-9914-B11AD3F37DEA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DB276308-5C05-4EEC-9914-B11AD3F37DEA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1BDF487C-4E58-424A-8BBE-0C2A74BE0AA6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1BDF487C-4E58-424A-8BBE-0C2A74BE0AA6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1BDF487C-4E58-424A-8BBE-0C2A74BE0AA6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1BDF487C-4E58-424A-8BBE-0C2A74BE0AA6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry.csproj
+++ b/src/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry.csproj
@@ -26,4 +26,8 @@
     <InternalsVisibleTo Include="Aydsko.iRacingTelemetry.UnitTests" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="../Aysdko.iRacingTelemetry.Generators/Aysdko.iRacingTelemetry.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="true" />
+  </ItemGroup>
+
 </Project>

--- a/src/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry/DiskClient.cs
+++ b/src/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry/DiskClient.cs
@@ -122,29 +122,29 @@ public class DiskClient : IDisposable
             var line = new List<Variable>(_header.NumberOfVariables);
             foreach (var headerVar in _headerVariables)
             {
-                Variable headerVariable = (headerVar.Type, headerVar.Count, CreateString(headerVar.Unit)) switch
+                Variable headerVariable = (headerVar.Type, headerVar.Count, headerVar.Unit) switch
                 {
-                    (0, 1, _) => new Variable<char>(CreateString(headerVar.Name), CreateString(headerVar.Description), CreateString(headerVar.Unit), MemoryMarshal.Cast<byte, char>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 1).Span)[0]),
-                    (1, 1, _) => new Variable<bool>(CreateString(headerVar.Name), CreateString(headerVar.Description), CreateString(headerVar.Unit), MemoryMarshal.Cast<byte, bool>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 1).Span)[0]),
-                    (2, 1, "irsdk_TrkSurf") => new Variable<TrackSurface>(CreateString(headerVar.Name), CreateString(headerVar.Description), CreateString(headerVar.Unit), (TrackSurface)MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span)[0]),
-                    (2, 1, "irsdk_TrkLoc") => new Variable<TrackLocation>(CreateString(headerVar.Name), CreateString(headerVar.Description), CreateString(headerVar.Unit), (TrackLocation)MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span)[0]),
-                    (2, 1, "irsdk_SessionState") => new Variable<SessionState>(CreateString(headerVar.Name), CreateString(headerVar.Description), CreateString(headerVar.Unit), (SessionState)MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span)[0]),
-                    (2, 1, "irsdk_PitSvStatus") => new Variable<PitServiceStatus>(CreateString(headerVar.Name), CreateString(headerVar.Description), CreateString(headerVar.Unit), (PitServiceStatus)MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span)[0]),
-                    (2, 1, "irsdk_CameraState") => new Variable<CameraState>(CreateString(headerVar.Name), CreateString(headerVar.Description), CreateString(headerVar.Unit), (CameraState)MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span)[0]),
-                    (2, 1, "irsdk_PaceMode") => new Variable<PaceMode>(CreateString(headerVar.Name), CreateString(headerVar.Description), CreateString(headerVar.Unit), (PaceMode)MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span)[0]),
-                    (2, 1, _) => new Variable<int>(CreateString(headerVar.Name), CreateString(headerVar.Description), CreateString(headerVar.Unit), MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span)[0]),
-                    (3, 1, "irsdk_Flags") => new Variable<GlobalState>(CreateString(headerVar.Name), CreateString(headerVar.Description), CreateString(headerVar.Unit), (GlobalState)MemoryMarshal.Cast<byte, uint>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span)[0]),
-                    (3, 1, "irsdk_PitSvFlags") => new Variable<PitService>(CreateString(headerVar.Name), CreateString(headerVar.Description), CreateString(headerVar.Unit), (PitService)MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span)[0]),
-                    (3, 1, "irsdk_EngineWarnings") => new Variable<EngineWarnings>(CreateString(headerVar.Name), CreateString(headerVar.Description), CreateString(headerVar.Unit), (EngineWarnings)MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span)[0]),
-                    (3, 1, _) => new Variable<int>(CreateString(headerVar.Name), CreateString(headerVar.Description), CreateString(headerVar.Unit), MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span)[0]),
-                    (4, 1, _) => new Variable<float>(CreateString(headerVar.Name), CreateString(headerVar.Description), CreateString(headerVar.Unit), MemoryMarshal.Cast<byte, float>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span)[0]),
-                    (5, 1, _) => new Variable<double>(CreateString(headerVar.Name), CreateString(headerVar.Description), CreateString(headerVar.Unit), MemoryMarshal.Cast<byte, double>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 8).Span)[0]),
-                    (0, > 1, _) => new Variable<char[]>(CreateString(headerVar.Name), CreateString(headerVar.Description), CreateString(headerVar.Unit), MemoryMarshal.Cast<byte, char>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 1).Span).ToArray()),
-                    (1, > 1, _) => new Variable<bool[]>(CreateString(headerVar.Name), CreateString(headerVar.Description), CreateString(headerVar.Unit), MemoryMarshal.Cast<byte, bool>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 1).Span).ToArray()),
-                    (2, > 1, _) => new Variable<int[]>(CreateString(headerVar.Name), CreateString(headerVar.Description), CreateString(headerVar.Unit), MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span).ToArray()),
-                    (3, > 1, _) => new Variable<int[]>(CreateString(headerVar.Name), CreateString(headerVar.Description), CreateString(headerVar.Unit), MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span).ToArray()),
-                    (4, > 1, _) => new Variable<float[]>(CreateString(headerVar.Name), CreateString(headerVar.Description), CreateString(headerVar.Unit), MemoryMarshal.Cast<byte, float>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span).ToArray()),
-                    (5, > 1, _) => new Variable<double[]>(CreateString(headerVar.Name), CreateString(headerVar.Description), CreateString(headerVar.Unit), MemoryMarshal.Cast<byte, double>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 8).Span).ToArray()),
+                    (0, 1, _) => new Variable<char>(headerVar.Name, headerVar.Description, headerVar.Unit, MemoryMarshal.Cast<byte, char>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 1).Span)[0]),
+                    (1, 1, _) => new Variable<bool>(headerVar.Name, headerVar.Description, headerVar.Unit, MemoryMarshal.Cast<byte, bool>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 1).Span)[0]),
+                    (2, 1, "irsdk_TrkSurf") => new Variable<TrackSurface>(headerVar.Name, headerVar.Description, headerVar.Unit, (TrackSurface)MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span)[0]),
+                    (2, 1, "irsdk_TrkLoc") => new Variable<TrackLocation>(headerVar.Name, headerVar.Description, headerVar.Unit, (TrackLocation)MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span)[0]),
+                    (2, 1, "irsdk_SessionState") => new Variable<SessionState>(headerVar.Name, headerVar.Description, headerVar.Unit, (SessionState)MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span)[0]),
+                    (2, 1, "irsdk_PitSvStatus") => new Variable<PitServiceStatus>(headerVar.Name, headerVar.Description, headerVar.Unit, (PitServiceStatus)MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span)[0]),
+                    (2, 1, "irsdk_CameraState") => new Variable<CameraState>(headerVar.Name, headerVar.Description, headerVar.Unit, (CameraState)MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span)[0]),
+                    (2, 1, "irsdk_PaceMode") => new Variable<PaceMode>(headerVar.Name, headerVar.Description, headerVar.Unit, (PaceMode)MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span)[0]),
+                    (2, 1, _) => new Variable<int>(headerVar.Name, headerVar.Description, headerVar.Unit, MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span)[0]),
+                    (3, 1, "irsdk_Flags") => new Variable<GlobalState>(headerVar.Name, headerVar.Description, headerVar.Unit, (GlobalState)MemoryMarshal.Cast<byte, uint>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span)[0]),
+                    (3, 1, "irsdk_PitSvFlags") => new Variable<PitService>(headerVar.Name, headerVar.Description, headerVar.Unit, (PitService)MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span)[0]),
+                    (3, 1, "irsdk_EngineWarnings") => new Variable<EngineWarnings>(headerVar.Name, headerVar.Description, headerVar.Unit, (EngineWarnings)MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span)[0]),
+                    (3, 1, _) => new Variable<int>(headerVar.Name, headerVar.Description, headerVar.Unit, MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span)[0]),
+                    (4, 1, _) => new Variable<float>(headerVar.Name, headerVar.Description, headerVar.Unit, MemoryMarshal.Cast<byte, float>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span)[0]),
+                    (5, 1, _) => new Variable<double>(headerVar.Name, headerVar.Description, headerVar.Unit, MemoryMarshal.Cast<byte, double>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 8).Span)[0]),
+                    (0, > 1, _) => new Variable<char[]>(headerVar.Name, headerVar.Description, headerVar.Unit, MemoryMarshal.Cast<byte, char>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 1).Span).ToArray()),
+                    (1, > 1, _) => new Variable<bool[]>(headerVar.Name, headerVar.Description, headerVar.Unit, MemoryMarshal.Cast<byte, bool>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 1).Span).ToArray()),
+                    (2, > 1, _) => new Variable<int[]>(headerVar.Name, headerVar.Description, headerVar.Unit, MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span).ToArray()),
+                    (3, > 1, _) => new Variable<int[]>(headerVar.Name, headerVar.Description, headerVar.Unit, MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span).ToArray()),
+                    (4, > 1, _) => new Variable<float[]>(headerVar.Name, headerVar.Description, headerVar.Unit, MemoryMarshal.Cast<byte, float>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 4).Span).ToArray()),
+                    (5, > 1, _) => new Variable<double[]>(headerVar.Name, headerVar.Description, headerVar.Unit, MemoryMarshal.Cast<byte, double>(valueBuffer.Slice(headerVar.Offset, headerVar.Count * 8).Span).ToArray()),
                     _ => throw new InvalidDataException("Unexpected header variable type value: " + headerVar.Type)
                 };
 
@@ -153,17 +153,6 @@ public class DiskClient : IDisposable
 
             yield return line.ToArray();
         }
-    }
-
-    private static string? CreateString(char[] chars)
-    {
-        if (chars is null or { Length: 0 } || chars[0] == '\0')
-        {
-            return null;
-        }
-
-        var value = new string(chars);
-        return value.TrimEnd('\0');
     }
 
     private static async Task<T> ReadFromStreamAsync<T>(FileStream stream, CancellationToken cancellation) where T : struct

--- a/src/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry/Examples/ExampleData.cs
+++ b/src/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry/Examples/ExampleData.cs
@@ -1,0 +1,24 @@
+﻿using Aysdko.iRacingTelemetry.Generators.Mapper;
+
+namespace Aydsko.iRacingTelemetry.Examples;
+
+/// <summary>
+/// Example class to show how the user can define the data he wants to be mapped from the iracing sdk
+/// </summary>
+[AysdkoData]
+public sealed class ExampleData
+{
+    // Auto convert time to TimeSpan
+    [AysdkoMap]
+    public TimeSpan SessionTime { get; set; }
+
+    // use different number types (as long as they can be converted)
+    [AysdkoMap]
+    public float Throttle { get; set; }
+    [AysdkoMap]
+    public double Brake { get; set; }
+
+    // Specify the iracing variable name explicitly when property has different name
+    [AysdkoMap("Clutch")]
+    public double ClutchPedal { get; set; }
+}

--- a/src/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry/Examples/UseMapperExample.cs
+++ b/src/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry/Examples/UseMapperExample.cs
@@ -1,0 +1,14 @@
+﻿namespace Aydsko.iRacingTelemetry.Examples;
+internal class UseMapperExample
+{
+    public static ExampleData UseMapper(IEnumerable<VariableHeader> headers, Span<byte> buffer)
+    {
+        // Create new mapper instance: this needs to be run once after connecting to a new session - at least each time the variable header changes
+        // The mapper can then be reused during the whole session
+        var mapper = new ExampleData_AysdkoMapper(headers);
+
+        // Create a single data frame from the current buffer
+        var data = mapper.MapFromBuffer(buffer);
+        return data;
+    }
+}

--- a/src/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry/IrSdkConstants.cs
+++ b/src/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry/IrSdkConstants.cs
@@ -7,13 +7,13 @@ internal static class IrSdkConstants
     public const int MaxDesc = 64;
     public const int MaximumBuffers = 4;
 
-    public static readonly int[] TypeBytes =
-    [
+    public static readonly int[] TypeBytes = new[]
+    {
         1, // Char
         1, // Bool
         4, // Int
         4, // BitField
         4, // Float
         8 // Double
-    ];
+    };
 }

--- a/src/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry/VariableBufferAccess.cs
+++ b/src/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry/VariableBufferAccess.cs
@@ -76,7 +76,7 @@ public static class VariableBufferAccess
         // special handling for TimeSpans -> iracing gives times in seconds
         if (targetType.Equals(typeof(TimeSpan)))
         {
-            return (T)(object)TimeSpan.FromSeconds(Convert.ToInt64(value, CultureInfo.InvariantCulture));
+            return (T)(object)TimeSpan.FromSeconds(Convert.ToDouble(value, CultureInfo.InvariantCulture));
         }
         
         return (T)Convert.ChangeType(value, targetType, CultureInfo.InvariantCulture);

--- a/src/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry/VariableBufferAccess.cs
+++ b/src/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry/VariableBufferAccess.cs
@@ -1,0 +1,68 @@
+﻿using System.Globalization;
+using System.Runtime.InteropServices;
+
+namespace Aydsko.iRacingTelemetry;
+public static class VariableBufferAccess
+{
+    public static object GetValue(Span<byte> valueBuffer, VariableHeader header)
+    {
+        var type = (VariableType)header.Type;
+        return (type, header.Count, new string(header.Unit)) switch
+        {
+            (VariableType.Char, 1, _) => MemoryMarshal.Cast<byte, char>(valueBuffer.Slice(header.Offset, header.Count * 1))[0],
+            (VariableType.Bool, 1, _) => MemoryMarshal.Cast<byte, bool>(valueBuffer.Slice(header.Offset, header.Count * 1))[0],
+            (VariableType.Int, 1, "irsdk_TrkSurf") => MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(header.Offset, header.Count * 4))[0],
+            (VariableType.Int, 1, "irsdk_TrkLoc") => (TrackLocation)MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(header.Offset, header.Count * 4))[0],
+            (VariableType.Int, 1, "irsdk_SessionState") => (SessionState)MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(header.Offset, header.Count * 4))[0],
+            (VariableType.Int, 1, "irsdk_PitSvStatus") => (PitServiceStatus)MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(header.Offset, header.Count * 4))[0],
+            (VariableType.Int, 1, "irsdk_CameraState") => (CameraState)MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(header.Offset, header.Count * 4))[0],
+            (VariableType.Int, 1, "irsdk_PaceMode") => (PaceMode)MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(header.Offset, header.Count * 4))[0],
+            (VariableType.Int, 1, _) => MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(header.Offset, header.Count * 4))[0],
+            (VariableType.BitField, 1, "irsdk_Flags") => (GlobalState)MemoryMarshal.Cast<byte, uint>(valueBuffer.Slice(header.Offset, header.Count * 4))[0],
+            (VariableType.BitField, 1, "irsdk_PitSvFlags") => (PitService)MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(header.Offset, header.Count * 4))[0],
+            (VariableType.BitField, 1, "irsdk_EngineWarnings") => (EngineWarnings)MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(header.Offset, header.Count * 4))[0],
+            (VariableType.BitField, 1, _) => MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(header.Offset, header.Count * 4))[0],
+            (VariableType.Float, 1, _) => MemoryMarshal.Cast<byte, float>(valueBuffer.Slice(header.Offset, header.Count * 4))[0],
+            (VariableType.Double, 1, _) => MemoryMarshal.Cast<byte, double>(valueBuffer.Slice(header.Offset, header.Count * 8))[0],
+            (VariableType.Char, > 1, _) => MemoryMarshal.Cast<byte, char>(valueBuffer.Slice(header.Offset, header.Count * 1)).ToArray(),
+            (VariableType.Bool, > 1, _) => MemoryMarshal.Cast<byte, bool>(valueBuffer.Slice(header.Offset, header.Count * 1)).ToArray(),
+            (VariableType.Int, > 1, _) => MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(header.Offset, header.Count * 4)).ToArray(),
+            (VariableType.BitField, > 1, _) => MemoryMarshal.Cast<byte, int>(valueBuffer.Slice(header.Offset, header.Count * 4)).ToArray(),
+            (VariableType.Float, > 1, _) => MemoryMarshal.Cast<byte, float>(valueBuffer.Slice(header.Offset, header.Count * 4)).ToArray(),
+            (VariableType.Double, > 1, _) => MemoryMarshal.Cast<byte, double>(valueBuffer.Slice(header.Offset, header.Count * 8)).ToArray(),
+            _ => throw new InvalidDataException("Unexpected header variable type value: " + header.Type),
+        };
+    }
+
+    /// <summary>
+    /// Read a single variable value from the buffer and convert to target data type
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="buffer"></param>
+    /// <param name="header"></param>
+    /// <returns></returns>
+    /// <exception cref="NotImplementedException"></exception>
+    public static T GetTypedValue<T>(Span<byte> buffer, VariableHeader header)
+    {
+        var value = GetValue(buffer, header);
+        var sourceType = GetDataType((VariableType)header.Type);
+        return SafeConvertType<T>(value, sourceType);
+    }
+
+    private static Type GetDataType(VariableType variableType) => variableType switch
+    {
+        VariableType.Char => typeof(char),
+        VariableType.Bool => typeof(bool),
+        VariableType.Int => typeof(int),
+        VariableType.BitField => typeof(int),
+        VariableType.Float => typeof(float),
+        VariableType.Double => typeof(double),
+        _ => typeof(object),
+    };
+
+    private static T SafeConvertType<T>(object value, Type sourceType)
+    {
+        // TODO: Implement safe type conversion between buffer data type and target type
+        throw new NotImplementedException();
+    }
+}

--- a/src/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry/VariableHeader.cs
+++ b/src/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry/VariableHeader.cs
@@ -24,14 +24,14 @@ public struct VariableHeader
     public char[] Padding;
 
     /// <summary>Name of the variable.</summary>
-    [MarshalAs(UnmanagedType.ByValArray, SizeConst = IrSdkConstants.MaxString)]
-    public char[] Name;
+    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = IrSdkConstants.MaxString)]
+    public string Name;
 
     /// <summary>A description for the variable.</summary>
-    [MarshalAs(UnmanagedType.ByValArray, SizeConst = IrSdkConstants.MaxDesc)]
-    public char[] Description;
+    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = IrSdkConstants.MaxDesc)]
+    public string Description;
 
     /// <summary>Units for the variable.</summary>
-    [MarshalAs(UnmanagedType.ByValArray, SizeConst = IrSdkConstants.MaxString)]
-    public char[] Unit;
+    [MarshalAs(UnmanagedType.ByValTStr, SizeConst = IrSdkConstants.MaxString)]
+    public string Unit;
 }

--- a/src/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry/VariableHeader.cs
+++ b/src/Aydsko.iRacingTelemetry/Aydsko.iRacingTelemetry/VariableHeader.cs
@@ -3,7 +3,7 @@
 namespace Aydsko.iRacingTelemetry;
 
 [StructLayout(LayoutKind.Sequential)]
-internal struct VariableHeader
+public struct VariableHeader
 {
     /// <summary>Type of data in this variable.</summary>
     /// <seealso cref="VariableType" />

--- a/src/Aydsko.iRacingTelemetry/Aysdko.iRacingTelemetry.Generators/Aysdko.iRacingTelemetry.Generators.csproj
+++ b/src/Aydsko.iRacingTelemetry/Aysdko.iRacingTelemetry.Generators/Aysdko.iRacingTelemetry.Generators.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>11</LangVersion>
+  </PropertyGroup>
+	
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
+    <PrivateAssets>all</PrivateAssets>
+    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/src/Aydsko.iRacingTelemetry/Aysdko.iRacingTelemetry.Generators/Mapper/AysdkoDataAttribute.cs
+++ b/src/Aydsko.iRacingTelemetry/Aysdko.iRacingTelemetry.Generators/Mapper/AysdkoDataAttribute.cs
@@ -1,0 +1,17 @@
+﻿namespace Aysdko.iRacingTelemetry.Generators.Mapper;
+
+/// <summary>
+/// This attribute marks a class or struct as a custom Aysdko data package
+/// A mapper for this class will be automatically generated with the name
+/// {ClassName}_AysdkoMapper
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+public sealed class AysdkoDataAttribute : Attribute
+{
+    public bool AutoMapAllProperties { get; }
+
+    public AysdkoDataAttribute(bool autoMapAllProperties = false)
+    {
+        AutoMapAllProperties = autoMapAllProperties;
+    }
+}

--- a/src/Aydsko.iRacingTelemetry/Aysdko.iRacingTelemetry.Generators/Mapper/AysdkoMapAttribute.cs
+++ b/src/Aydsko.iRacingTelemetry/Aysdko.iRacingTelemetry.Generators/Mapper/AysdkoMapAttribute.cs
@@ -1,0 +1,12 @@
+﻿namespace Aysdko.iRacingTelemetry.Generators.Mapper;
+
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+public sealed class AysdkoMapAttribute : Attribute
+{
+    public string? IrsdkVariableName { get; }
+
+    public AysdkoMapAttribute(string? irsdkVariableName = null)
+    {
+        IrsdkVariableName = irsdkVariableName;
+    }
+}

--- a/src/Aydsko.iRacingTelemetry/Aysdko.iRacingTelemetry.Generators/Mapper/AysdkoMapperContext.cs
+++ b/src/Aydsko.iRacingTelemetry/Aysdko.iRacingTelemetry.Generators/Mapper/AysdkoMapperContext.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.CodeAnalysis;
+
+namespace Aysdko.iRacingTelemetry.Generators.Mapper;
+internal sealed class AysdkoMapperContext
+{
+    public string TargetNamespace { get; }
+    public string TargetClassName { get; }
+    public IReadOnlyCollection<(string mapName, IPropertySymbol property)> MappedProperties { get; }
+
+    public AysdkoMapperContext(string targetNamespace, string targetClassName, IReadOnlyCollection<(string name, IPropertySymbol property)> mappedProperties)
+    {
+        TargetClassName = targetClassName;
+        TargetNamespace = targetNamespace;
+        MappedProperties = mappedProperties;
+    }
+}

--- a/src/Aydsko.iRacingTelemetry/Aysdko.iRacingTelemetry.Generators/Mapper/AysdkoMapperGenerator.cs
+++ b/src/Aydsko.iRacingTelemetry/Aysdko.iRacingTelemetry.Generators/Mapper/AysdkoMapperGenerator.cs
@@ -1,0 +1,108 @@
+﻿using System.Text;
+using Microsoft.CodeAnalysis;
+
+namespace Aysdko.iRacingTelemetry.Generators.Mapper;
+
+[Generator]
+internal sealed class AysdkoMapperGenerator : ISourceGenerator
+{
+    // class and method names from Aysdko.iRacingTelemetry project
+    // --> this project cannot be linked to the source generator because it would create a cyclic dependency
+    //     therefore the names of classes and methods need to be provided as string constants
+    private const string VariableHeaderClass = "VariableHeader";
+    private const string VariableHeaderNameProperty = "Name";
+    private const string VariableBufferAccessClass = "VariableBufferAccess";
+    private const string GetTypedValueMethod = "GetTypedValue";
+
+    public void Execute(GeneratorExecutionContext context)
+    {
+        if (context.SyntaxContextReceiver is AysdkoMapperSyntaxReceiver syntaxReceiver == false)
+        {
+            return;
+        }
+
+        foreach(var mapperContext in syntaxReceiver.Contexts)
+        {
+            CreateMapperSource(context, mapperContext);
+        }
+    }
+
+    public void Initialize(GeneratorInitializationContext context)
+    {
+        context.RegisterForSyntaxNotifications(() => new AysdkoMapperSyntaxReceiver());
+    }
+
+    private static void CreateMapperSource(GeneratorExecutionContext context, AysdkoMapperContext mapperContext)
+    {
+        var sourceBuilder = new StringBuilder();
+        var mapperClassName = $"{mapperContext.TargetClassName}_AysdkoMapper";
+
+        // write header, using, namespace and class definition
+        sourceBuilder.Append($$"""
+            // Auto generated code from Aysdko.iRacingTelemetry
+            // Changes will be ovewritten
+            using System;
+            using Aysdko.iRacingTelemetry;
+            using Aysdko.iRacingTelemetry.Generators.Mapper;
+
+            namespace {{mapperContext.TargetNamespace}};
+
+            public sealed class {{mapperClassName}} : {{nameof(IAysdkoMapper<object>)}}<{{mapperContext.TargetClassName}}>
+            {
+            """);
+
+        // write stored headers for each mapped variable
+        foreach(var (_, property) in mapperContext.MappedProperties)
+        {
+            sourceBuilder.Append($$"""
+                private {{VariableHeaderClass}}? {{property.Name}}_Header { get; }
+
+            """);
+        }
+
+        // write constructor
+        sourceBuilder.Append($$"""
+                
+                public {{mapperClassName}}(IEnumerable<{{VariableHeaderClass}}> variableHeaders)
+                {
+
+            """);
+        foreach(var (mapName, property) in mapperContext.MappedProperties)
+        {
+            sourceBuilder.Append($$"""
+                    {{property.Name}}_Header = variableHeaders.FirstOrDefault(x => new string(x.{{VariableHeaderNameProperty}}) == "{{mapName}}");
+
+            """);
+        }
+        sourceBuilder.Append("""
+                }
+            """);
+
+        // write map method
+        var accessClass = 
+        sourceBuilder.Append($$"""
+                
+                public {{mapperContext.TargetClassName}} {{nameof(IAysdkoMapper<object>.MapFromBuffer)}}(Span<byte> buffer)
+                {
+                    var target = new {{mapperContext.TargetClassName}}();
+
+            """);
+        foreach(var (_, property) in mapperContext.MappedProperties)
+        {
+            sourceBuilder.Append($$"""
+                    target.{{property.Name}} = {{property.Name}}_Header is null ? default : {{VariableBufferAccessClass}}.{{GetTypedValueMethod}}<{{property.Type.ToDisplayString()}}>(buffer, {{property.Name}}_Header.Value);
+
+            """);
+        }
+        sourceBuilder.Append("""
+                    return target;
+                }
+
+            """);
+
+        // end of class
+        sourceBuilder.AppendLine("}");
+
+        context.AddSource($"{mapperClassName}.generated", sourceBuilder.ToString());
+    }
+}

--- a/src/Aydsko.iRacingTelemetry/Aysdko.iRacingTelemetry.Generators/Mapper/AysdkoMapperSyntaxReceiver.cs
+++ b/src/Aydsko.iRacingTelemetry/Aysdko.iRacingTelemetry.Generators/Mapper/AysdkoMapperSyntaxReceiver.cs
@@ -1,0 +1,73 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Aysdko.iRacingTelemetry.Generators.Mapper;
+internal sealed class AysdkoMapperSyntaxReceiver : ISyntaxContextReceiver
+{
+    private readonly List<AysdkoMapperContext> contexts = new();
+    public IEnumerable<AysdkoMapperContext> Contexts => contexts;
+
+    public void OnVisitSyntaxNode(GeneratorSyntaxContext context)
+    {
+        if (context.Node is ClassDeclarationSyntax cds == false)
+        {
+            return;
+        }
+
+        var declaredClassSymbol = context.SemanticModel.GetDeclaredSymbol(cds);
+        if (declaredClassSymbol is null)
+        {
+            return;
+        }
+
+        // check if data package attribute was declared
+        var dataPackageAttribute = declaredClassSymbol
+            .GetAttributes()
+            .FirstOrDefault(x => x.AttributeClass?.Name == nameof(AysdkoDataAttribute));
+        if (dataPackageAttribute is null)
+        {
+            return;
+        }
+
+        // get value for auto mapping properties passed as constructor argument
+        var autoMapProperties = (bool)(dataPackageAttribute.ConstructorArguments.FirstOrDefault().Value ?? false);
+
+        var mapProperties = cds.ChildNodes()
+            .OfType<PropertyDeclarationSyntax>()
+            .Select(x => context.SemanticModel.GetDeclaredSymbol(x) as IPropertySymbol)
+            .Where(x => x is not null)
+            .Select(x => (name: x!.Name, property: x));
+        if (autoMapProperties == false)
+        {
+            // only map properties with mapping attribute
+            mapProperties = mapProperties
+                .Where(x => x.property.GetAttributes()
+                    .Any(y => y.AttributeClass?.Name == nameof(AysdkoMapAttribute)))
+                .Select(x => (name: GetMappedName(x.property.GetAttributes().First(y => y.AttributeClass?.Name == nameof(AysdkoMapAttribute))) ?? x.name, x.property));
+        }
+
+        var targetNameSpace = GetFullNamespace(declaredClassSymbol.ContainingNamespace);
+        var mapperContext = new AysdkoMapperContext(
+            targetNameSpace,
+            declaredClassSymbol.Name,
+            mapProperties.ToList()
+        );
+
+        contexts.Add(mapperContext);
+    }
+
+    private string GetFullNamespace(INamespaceSymbol symbol)
+    {
+        var parentNamespace = symbol.ContainingNamespace;
+        if (string.IsNullOrEmpty(parentNamespace?.Name))
+        {
+            return symbol.Name;
+        }
+        return $"{GetFullNamespace(parentNamespace!)}.{symbol.Name}";
+    }
+
+    private static string? GetMappedName(AttributeData mapAttribute)
+    {
+        return mapAttribute.ConstructorArguments.FirstOrDefault().Value?.ToString();
+    }
+}

--- a/src/Aydsko.iRacingTelemetry/Aysdko.iRacingTelemetry.Generators/Mapper/IAysdkoMapper.cs
+++ b/src/Aydsko.iRacingTelemetry/Aysdko.iRacingTelemetry.Generators/Mapper/IAysdkoMapper.cs
@@ -1,0 +1,5 @@
+﻿namespace Aysdko.iRacingTelemetry.Generators.Mapper;
+public interface IAysdkoMapper<T> where T : class
+{
+    T MapFromBuffer(Span<byte> buffer);
+}


### PR DESCRIPTION
## Feature description
This PR will add a source generator that can generate mapping code for automatically reading data from an iracing data buffer to a user defined class.

## How does this work?
The source generator looks for classes that have the `[AysdkoData]` attribute and generates a mapper class for each.
The mapper class has a single constructor that takes in the current list of variable headers.
After initializing the mapper a single instance of the user defined class can be directly created by calling `MapFromBuffer()` and providing the current iracing data buffer.